### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'timestamp'

### DIFF
--- a/parsers/qualcommparser.py
+++ b/parsers/qualcommparser.py
@@ -49,7 +49,7 @@ class QualcommParser:
         self.writerSIM1 = writerSIM1
         self.writerSIM2 = writerSIM2
 
-    def writeCP(self, pkt_content, radio_id, ts=None):
+    def writeCP(self, pkt_content, radio_id, ts=datetime.datetime.now()):
         if radio_id == 0:
             self.writerSIM1.write_cp(pkt_content, ts)
         elif radio_id == 1:
@@ -57,7 +57,7 @@ class QualcommParser:
         else:
             self.logger.log(logging.WARNING, "Unknown radio_id {}".format(radio_id))
 
-    def writeUP(self, pkt_content, radio_id, ts=None):
+    def writeUP(self, pkt_content, radio_id, ts=datetime.datetime.now()):
         if radio_id == 0:
             self.writerSIM1.write_up(pkt_content, ts)
         elif radio_id == 1:

--- a/parsers/samsungparser.py
+++ b/parsers/samsungparser.py
@@ -50,7 +50,7 @@ class SamsungParser:
         self.writerSIM1 = writerSIM1
         self.writerSIM2 = writerSIM2
 
-    def writeCP(self, pkt_content, radio_id, ts=None):
+    def writeCP(self, pkt_content, radio_id, ts=datetime.datetime.now()):
         if radio_id == 0:
             self.writerSIM1.write_cp(pkt_content, ts)
         elif radio_id == 1:
@@ -58,7 +58,7 @@ class SamsungParser:
         else:
             self.logger.log(logging.WARNING, "Unknown radio_id {}".format(radio_id))
 
-    def writeUP(self, pkt_content, radio_id, ts=None):
+    def writeUP(self, pkt_content, radio_id, ts=datetime.datetime.now()):
         if radio_id == 0:
             self.writerSIM1.write_up(pkt_content, ts)
         elif radio_id == 1:


### PR DESCRIPTION
I have often encountered this problem using the option -F. This how I fixed it, but you know the logic better of course :)

Traceback (most recent call last):
  File "./scat.py", line 401, in <module>
    current_parser.run_diag()
  File "C:\Users\handy\Documents\GitHub\scat-my\parsers\qualcommparser.py", line 192, in run_diag
    self.parse_diag(pkt)
  File "C:\Users\handy\Documents\GitHub\scat-my\parsers\qualcommparser.py", line 164, in parse_diag
    self.parse_diag_multisim(pkt)
  File "C:\Users\handy\Documents\GitHub\scat-my\parsers\qualcommparser.py", line 2092, in parse_diag_multisim
    radio_id = (xdm_hdr[3] - 1))
  File "C:\Users\handy\Documents\GitHub\scat-my\parsers\qualcommparser.py", line 155, in parse_diag
    self.parse_diag_log(pkt, radio_id)
  File "C:\Users\handy\Documents\GitHub\scat-my\parsers\qualcommparser.py", line 2035, in parse_diag_log
    process[xdm_hdr[1]](pkt_ts, pkt_body, radio_id)
  File "C:\Users\handy\Documents\GitHub\scat-my\parsers\qualcommparser.py", line 1988, in <lambda>
    0x412F: lambda x, y, z: self.parse_wcdma_rrc(x, y, z), # WCDMA Signaling Messages
  File "C:\Users\handy\Documents\GitHub\scat-my\parsers\qualcommparser.py", line 783, in parse_wcdma_rrc
    self.writeCP(gsmtap_hdr + msg_content, radio_id)
  File "C:\Users\handy\Documents\GitHub\scat-my\parsers\qualcommparser.py", line 54, in writeCP
    self.writerSIM1.write_cp(pkt_content, ts)
  File "./scat.py", line 204, in write_cp
    self.write_pkt(sock_content, self.port_cp, ts)
  File "./scat.py", line 172, in write_pkt
    int(ts.timestamp()),
AttributeError: 'NoneType' object has no attribute 'timestamp'