### PR TITLE
Fix qmdl writer

### DIFF
--- a/scat.py
+++ b/scat.py
@@ -153,7 +153,7 @@ if __name__ == '__main__':
         signal.signal(signal.SIGINT, sigint_handler)
 
         if not (args.qmdl == None) and args.type == 'qc':
-            current_parser.run_diag(RawWriter(args.qmdl))
+            current_parser.run_diag(writers.RawWriter(args.qmdl))
         else:
             current_parser.run_diag()
 


### PR DESCRIPTION
It's just a small fix to avoid:
```
Traceback (most recent call last):
  File "scat.py", line 156, in <module>
    current_parser.run_diag(RawWriter(args.qmdl))
NameError: name 'RawWriter' is not defined
```