### PR TITLE
Add an option to list usb devices

### DIFF
--- a/iodevices/usbio.py
+++ b/iodevices/usbio.py
@@ -77,3 +77,17 @@ class USBIO:
     def __exit__(self, exc_type, exc_value, traceback):
         if self.usb_dev is not None:
             usb.util.dispose_resources(self.usb_dev)
+
+    @staticmethod
+    def list_usb_devices():
+        # find all USB devices
+        if usb.core.find() is not None:
+            devs = usb.core.find(find_all=True)
+            print('List of usb devices:')
+            # loop through devices
+            for dev in devs:
+                print('Bus {:03d} Device {:03d}: ID {:04X}:{:04X}'.format(dev.bus, dev.address, dev.idVendor,
+                                                                          dev.idProduct),
+                      usb.util.get_string(dev, dev.iManufacturer), usb.util.get_string(dev, dev.iProduct))
+        else:
+            print('No usb device found')

--- a/scat.py
+++ b/scat.py
@@ -45,6 +45,15 @@ if __name__ == '__main__':
     parsers_desc = ', '.join(parser_dict.keys())
 
     parser = argparse.ArgumentParser(description='Reads diagnostic messages from smartphone baseband.')
+
+    parser.add_argument('-l', '--list-devices', help='List usb devices', action='store_true')
+    args = parser.parse_known_args()
+
+    # list usb devices and then exit
+    if args[0].list_devices:
+        iodevices.USBIO().list_usb_devices()
+        sys.exit(0)
+
     parser.add_argument('-D', '--debug', help='Print debug information, mostly hexdumps.', action='store_true')
     parser.add_argument('-t', '--type', help='Baseband type to be parsed.\nAvailable types: %s' % parsers_desc, required=True)
 


### PR DESCRIPTION
I know that the target of this program is linux, but it works on other OS too, such as Windows (with [libusbK](http://libusbk.sourceforge.net/UsbK3/index.html)) and Android (with [libusb for Android](https://github.com/libusb/libusb/tree/master/android)), which don't natively support libusb.
This addition would make "life easier" for those who use scat on these OS. 

To list usb devices you have to run scat with option -l or --list-devices, scat will list usb devices in a format similar to that of lsub and then will exit.
````
C:\scat> python.exe scat.py -l
List of usb devices:
Bus 000 Device 255: ID 05C6:9091 Sony G8341
````

