### PR TITLE
Improve qualcomm parser

### DIFF
--- a/parsers/qualcomm/diagltelogparser.py
+++ b/parsers/qualcomm/diagltelogparser.py
@@ -682,7 +682,7 @@ class DiagLteLogParser:
                     pos += subpkt_size
                     continue
 
-                if subpkt_ver == 0x01:
+                if subpkt_ver == 0x01 or subpkt_ver == 0x28:
                     pos += 4
                     pos += 32
                     ciphering_algo = pkt[pos]
@@ -735,7 +735,7 @@ class DiagLteLogParser:
                     pos += subpkt_size
                     continue
 
-                if subpkt_ver == 0x01:
+                if subpkt_ver == 0x01 or subpkt_ver == 0x28:
                     pos += 4
                     pos += 32
                     ciphering_algo = pkt[pos]

--- a/parsers/qualcomm/diagltelogparser.py
+++ b/parsers/qualcomm/diagltelogparser.py
@@ -701,7 +701,7 @@ class DiagLteLogParser:
                         # Has header on PDU, CP (0x01), no ROHC
                         # Direction: Downlink (0x01)
                         ws_hdr = bytes([0x00, 0x01, 0x00, 0x03, 0x01, 0x01])
-                        self.parent.writer.write_cp(b'pdcp-lte' + ws_hdr + pdcp_pdu, radio_id, pkt_ts)
+                        self.parent.writer.write_up(b'pdcp-lte' + ws_hdr + pdcp_pdu, radio_id, pkt_ts)
                         pos_sample += (20 + pdu_hdr[2])
 
                 else:
@@ -754,7 +754,7 @@ class DiagLteLogParser:
                         # Has header on PDU, CP (0x01), no ROHC
                         # Direction: Uplink (0x00)
                         ws_hdr = bytes([0x00, 0x01, 0x00, 0x03, 0x00, 0x01])
-                        self.parent.writer.write_cp(b'pdcp-lte' + ws_hdr + pdcp_pdu, radio_id, pkt_ts)
+                        self.parent.writer.write_up(b'pdcp-lte' + ws_hdr + pdcp_pdu, radio_id, pkt_ts)
                         pos_sample += (16 + pdu_hdr[2])
 
                 else:

--- a/parsers/qualcomm/diagltelogparser.py
+++ b/parsers/qualcomm/diagltelogparser.py
@@ -903,7 +903,7 @@ class DiagLteLogParser:
             # XXX: needs proper field for physical cell id
             sfn = sfn | (p_cell_id << 16)
 
-        elif pkt[0] in (0x08, 0x09, 0x0c, 0x0d, 0x0f, 0x10, 0x13, 0x14, 0x16): # Version 8, 9, 12, 13, 15, 16, 19, 20, 22
+        elif pkt[0] in (0x08, 0x09, 0x0c, 0x0d, 0x0f, 0x10, 0x13, 0x14, 0x16, 0x18): # Version 8, 9, 12, 13, 15, 16, 19, 20, 22, 24
             # 08 | 0a 72 | 01 | 0e 00 | 9c 18 00 00 | a9 33 | 06 | 00 00 00 00 | 02 00 | 2e 02
             # 09 | 0b 70 | 00 | 00 01 | 14 05 00 00 | 09 91 | 0b | 00 00 00 00 | 07 00 | 40 0b 8e c1 dd 13 b0
             # 0d | 0c 74 | 01 | 32 00 | 38 18 00 00 | 00 00 | 08 | 00 00 00 00 | 02 00 | 2c 00
@@ -911,6 +911,7 @@ class DiagLteLogParser:
             # 0f | 0d 21 | 01 | 9e 00 | 14 05 00 00 | 00 00 | 09 | 00 00 00 00 | 1c 00 | 08 10 a5 34 61 41 a3 1c 31 68 04 40 1a 00 49 16 7c 23 15 9f 00 10 67 c1 06 d9 e0 00 fd 2d
             # 13 | 0e 22 | 00 | 0b 00 | fa 09 00 00 | 00 00 | 32 | 00 00 00 00 | 09 00 | 28 18 40 16 08 08 80 00 00
             # 14 | 0e 30 | 01 | 09 01 | 9c 18 00 00 | 00 00 | 09 | 00 00 00 00 | 18 00 | 08 10 a7 14 53 59 a6 05 43 68 c0 3b da 30 04 a6 88 02 8d a2 00 9a 68 40
+            # 18 | 0f 22 | 00 | 68 00 | e4 0c 00 00 | 09 dc | 05 | 00 00 00 00 | 0d 00 | 40 85 8e c4 e5 bf e0 50 dc 29 15 16 00
             msg_hdr = pkt[0:19] # 19 bytes
             msg_content = pkt[19:] # Rest of packet
             if len(msg_hdr) != 19:
@@ -1043,8 +1044,8 @@ class DiagLteLogParser:
                 50: util.gsmtap_lte_rrc_types.UL_CCCH_NB,
                 52: util.gsmtap_lte_rrc_types.UL_DCCH_NB
             }
-        elif pkt[0] in (0x14,):
-            # RRC Packet v20
+        elif pkt[0] in (0x14, 0x18):
+            # RRC Packet v20, v24
             rrc_subtype_map = {
                 1: util.gsmtap_lte_rrc_types.BCCH_BCH,
                 2: util.gsmtap_lte_rrc_types.BCCH_DL_SCH,

--- a/parsers/qualcomm/diagltelogparser.py
+++ b/parsers/qualcomm/diagltelogparser.py
@@ -1065,9 +1065,9 @@ class DiagLteLogParser:
             return 
 
         sub_type = rrc_subtype_map[subtype]
-        # Invert EARFCN for UL-CCCH/UL-DCCH
+        # UL-EARFCN for UL-CCCH/UL-DCCH
         if sub_type == util.gsmtap_lte_rrc_types.UL_CCCH or sub_type == util.gsmtap_lte_rrc_types.UL_DCCH:
-            earfcn = earfcn | 0x4000
+            earfcn = util.calculate_ul_earfcn(earfcn)
 
         gsmtap_hdr = util.create_gsmtap_header(
             version = 3,

--- a/parsers/qualcomm/diagltelogparser.py
+++ b/parsers/qualcomm/diagltelogparser.py
@@ -894,8 +894,6 @@ class DiagLteLogParser:
             earfcn = msg_hdr[5]
             self.parent.lte_last_earfcn_dl[self.parent.sanitize_radio_id(radio_id)] = earfcn
             self.parent.lte_last_cell_id[self.parent.sanitize_radio_id(radio_id)] = p_cell_id
-            if msg_hdr[7] == 7 or msg_hdr[7] == 8: # Invert EARFCN for UL-CCCH/UL-DCCH
-                earfcn = earfcn | 0x4000
             sfn = (msg_hdr[6] & 0xfff0) >> 4
             self.parent.lte_last_sfn[self.parent.sanitize_radio_id(radio_id)] = sfn
             subfn = msg_hdr[6] & 0xf
@@ -921,8 +919,6 @@ class DiagLteLogParser:
             earfcn = msg_hdr[4]
             self.parent.lte_last_earfcn_dl[self.parent.sanitize_radio_id(radio_id)] = earfcn
             self.parent.lte_last_cell_id[self.parent.sanitize_radio_id(radio_id)] = p_cell_id
-            if msg_hdr[6] == 7 or msg_hdr[6] == 8: # Invert EARFCN for UL-CCCH/UL-DCCH
-                earfcn = earfcn | 0x4000
             sfn = (msg_hdr[5] & 0xfff0) >> 4
             self.parent.lte_last_sfn[self.parent.sanitize_radio_id(radio_id)] = sfn
             subfn = msg_hdr[5] & 0xf
@@ -943,8 +939,6 @@ class DiagLteLogParser:
             earfcn = msg_hdr[4]
             self.parent.lte_last_earfcn_dl[self.parent.sanitize_radio_id(radio_id)] = earfcn
             self.parent.lte_last_cell_id[self.parent.sanitize_radio_id(radio_id)] = p_cell_id
-            if msg_hdr[6] == 7 or msg_hdr[6] == 8: # Invert EARFCN for UL-CCCH/UL-DCCH
-                earfcn = earfcn | 0x4000
             sfn = (msg_hdr[5] & 0xfff0) >> 4
             self.parent.lte_last_sfn[self.parent.sanitize_radio_id(radio_id)] = sfn
             subfn = msg_hdr[5] & 0xf
@@ -964,8 +958,6 @@ class DiagLteLogParser:
             earfcn = msg_hdr[4]
             self.parent.lte_last_earfcn_dl[self.parent.sanitize_radio_id(radio_id)] = earfcn
             self.parent.lte_last_cell_id[self.parent.sanitize_radio_id(radio_id)] = p_cell_id
-            if msg_hdr[6] == 7 or msg_hdr[6] == 8: # Invert EARFCN for UL-CCCH/UL-DCCH
-                earfcn = earfcn | 0x4000
             sfn = (msg_hdr[5] & 0xfff0) >> 4
             self.parent.lte_last_sfn[self.parent.sanitize_radio_id(radio_id)] = sfn
             subfn = msg_hdr[5] & 0xf
@@ -1072,12 +1064,17 @@ class DiagLteLogParser:
             self.parent.logger.log(logging.DEBUG, util.xxd(pkt))
             return 
 
+        sub_type = rrc_subtype_map[subtype]
+        # Invert EARFCN for UL-CCCH/UL-DCCH
+        if sub_type == util.gsmtap_lte_rrc_types.UL_CCCH or sub_type == util.gsmtap_lte_rrc_types.UL_DCCH:
+            earfcn = earfcn | 0x4000
+
         gsmtap_hdr = util.create_gsmtap_header(
             version = 3,
             payload_type = util.gsmtap_type.LTE_RRC,
             arfcn = earfcn,
             frame_number = sfn,
-            sub_type = rrc_subtype_map[subtype],
+            sub_type = sub_type,
             sub_slot = subfn,
             device_sec = ts_sec,
             device_usec = ts_usec)

--- a/parsers/qualcomm/diagltelogparser.py
+++ b/parsers/qualcomm/diagltelogparser.py
@@ -892,12 +892,12 @@ class DiagLteLogParser:
             msg_hdr = struct.unpack('<BHHBHLHBLH', msg_hdr) # Version, RRC Release, NR RRC Release, RBID, Physical CID, EARFCN, SysFN/SubFN, PDUN, Len0, Len1
             p_cell_id = msg_hdr[4]
             earfcn = msg_hdr[5]
-            self.parent.lte_last_earfcn_dl[radio_id] = earfcn
-            self.parent.lte_last_cell_id[radio_id] = p_cell_id
+            self.parent.lte_last_earfcn_dl[self.parent.sanitize_radio_id(radio_id)] = earfcn
+            self.parent.lte_last_cell_id[self.parent.sanitize_radio_id(radio_id)] = p_cell_id
             if msg_hdr[7] == 7 or msg_hdr[7] == 8: # Invert EARFCN for UL-CCCH/UL-DCCH
                 earfcn = earfcn | 0x4000
             sfn = (msg_hdr[6] & 0xfff0) >> 4
-            self.parent.lte_last_sfn[radio_id] = sfn
+            self.parent.lte_last_sfn[self.parent.sanitize_radio_id(radio_id)] = sfn
             subfn = msg_hdr[6] & 0xf
             subtype = msg_hdr[7]
             # XXX: needs proper field for physical cell id

--- a/util.py
+++ b/util.py
@@ -311,3 +311,28 @@ def create_osmocore_logging_header(timestamp = datetime.datetime.now(),
     )
 
     return logging_hdr
+
+
+# Calculates the equivalent UL-EARFCN of a given DL-EARFCN,
+# if the input is an SDL or unknown EARFCN the output will be equal to the input
+# Based on 3GPP TS 36.101 V16.6.0 Table 5.7.3-1
+def calculate_ul_earfcn(dl_earfcn):
+    if 0 <= dl_earfcn < 9660:        # B1-B28
+        offset = 18000
+    elif 9769 < dl_earfcn < 9920:    # B30-31
+        offset = 17890
+    elif 65535 < dl_earfcn < 67136:  # B65-66
+        offset = 65536
+    elif 67535 < dl_earfcn < 67836:  # B68
+        offset = 65136
+    elif 68335 < dl_earfcn < 68486:  # B70
+        offset = 64636
+    elif 68585 < dl_earfcn < 69466:  # B71-74
+        offset = 64536
+    elif 70365 < dl_earfcn < 70596:  # B85-87
+        offset = 63636
+    elif 70595 < dl_earfcn < 70646:  # B88
+        offset = 63635
+    else:
+        offset = 0
+    return dl_earfcn + offset

--- a/util.py
+++ b/util.py
@@ -78,9 +78,10 @@ def parse_qxdm_ts(ts):
     
     try:
         ts_delta = datetime.timedelta(0, 0, 0, ts_upper * 1.25 + ts_lower * (1 / 40960), 0, 0, 0)
+        date = epoch + ts_delta
     except OverflowError:
-        ts_delta = datetime.timedelta(seconds=0)
-    return epoch + ts_delta
+        date = epoch + datetime.timedelta(seconds=0)
+    return date
 
 def xxd(buf, stdout = False):
     xxd_str = ''


### PR DESCRIPTION
This pull request contains some changes to qualcomm LTE parser, I put them in one pull request to avoid creating many, but if you like separate pull requests let me know.
The commits are quite self explaintory. I want to point out that in the commit bf9decc I assumed that inverting the EARFCN was a way to calculate the uplink EARFCN.
I know that the commit 5bcc03c can be a bit controversial, I had that problem with wireshark and in my opinion that change is the best way to solve it