### PR TITLE
Added support for 0xB193 v48

### DIFF
--- a/parsers/qualcomm/diagltelogparser.py
+++ b/parsers/qualcomm/diagltelogparser.py
@@ -235,7 +235,7 @@ class DiagLteLogParser:
                     scell_subpkt = scell_subpkt[4:]
 
                     if scell_measurement_version == 48:
-                        earfcn, num_cell, valid_rx, rx_map = struct.unpack('<LHH', scell_subpkt[0:12])
+                        earfcn, num_cell, valid_rx, rx_map = struct.unpack('<LHHL', scell_subpkt[0:12])
                         interim = struct.unpack('<HHH', scell_subpkt[12:18])
                         pci = interim[0] & 511
                         scell_idx = (interim[0] >> 9) & 7


### PR DESCRIPTION
This pull request contains support for decoding 0xB193 (LTE ML1 Serving Cell Meas Response) v48 which can be found in new devices like Samsung S20. Please merge this to resolve issue #33.