### PR TITLE
Added installation instruction for macOS powered by Apple silicon

### DIFF
--- a/Apple-silicon.md
+++ b/Apple-silicon.md
@@ -1,0 +1,23 @@
+# Apple silicon
+
+## Install libusb
+Make sure you have installed brew (a elegent package manager for macOS, [https://brew.sh/](https://brew.sh/)).
+``` brew install libusb```
+
+If you encount following issue:
+```
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/usb/core.py", line 1299, in find
+    raise NoBackendError('No backend available')
+usb.core.NoBackendError: No backend available
+```
+You can following this link [issues/355](https://github.com/pyusb/pyusb/issues/355#issuecomment-974726078) to solve it.
+```
+ln -s /opt/homebrew/lib/libusb-1.0.0.dylib //usr/local/lib/libusb.dylib
+```
+After this, you can validate libusb whether works as weel by executing following command.
+```
+$ /opt/homebrew/opt/python@3.8/bin/python3 -c "import ctypes.util; print(ctypes.util.find_library('usb'))"
+/opt/homebrew/lib/libusb.dylib
+```

--- a/README.md
+++ b/README.md
@@ -141,3 +141,5 @@ software to cite one of these references listed below:
   Cellular Walled Gardens - A Method for Closed Network Diagnosis -**. IEEE
   Transactions on Mobile Computing, February 2018.
 
+## For Apple silicon
+[doc](Apple-silicon.md).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyserial==3.4
-pyusb==1.0.2
+pyusb==1.2.1


### PR DESCRIPTION
Contributions are as follows:
- [1 ] added instruction for macOS powered by Apple silicon
- [2] upgrade pyusb from 1.0.2 to 1.2.1