### PR TITLE
Fixes for args

### DIFF
--- a/iodevices/usbio.py
+++ b/iodevices/usbio.py
@@ -41,8 +41,8 @@ class USBIO:
             raise ValueError('Device not found')
 
     def probe_device_by_bus_dev(self, bus, dev):
-        print('Trying USB device at address {:03d}:{:03d}'.format(bus, dev))
-        self.dev = usb.core.find(bus=bus, address=dev)
+        print('Trying USB device at address {:03x}:{:03x}'.format(bus, dev))
+        self.dev = usb.core.find(idVendor=bus, idProduct=dev)
         if self.dev is None:
             raise ValueError('Device not found')
 

--- a/scat.py
+++ b/scat.py
@@ -106,8 +106,8 @@ if __name__ == '__main__':
         io_device = iodevices.USBIO()
         if args.address:
             usb_bus, usb_device = args.address.split(':')
-            usb_bus = int(usb_bus, base=10)
-            usb_device = int(usb_device, base=10)
+            usb_bus = int(usb_bus, base=16)
+            usb_device = int(usb_device, base=16)
             io_device.probe_device_by_bus_dev(usb_bus, usb_device)
         elif args.vendor == None:
             io_device.guess_device()


### PR DESCRIPTION
1. Use base 16 for parsing usb bus an device
2. Named args changes as per usb.core.find function

Testing environment:
- Ubuntu 22.04
- Python 3.10.4
- pyserial 3.5
- pyusb 1.2.1
- Phone - Oneplus 5