### PR TITLE
Add experimental hdf parser

### DIFF
--- a/parsers/qualcomm/qualcommparser.py
+++ b/parsers/qualcomm/qualcommparser.py
@@ -359,7 +359,9 @@ class QualcommParser:
             body += self.io_device.read(pkt_len - 2)
             pkt = header + body
 
-            self.parse_diag(pkt, check_crc=False, hdlc_encoded=False)
+            parse_result = self.parse_diag(pkt, check_crc=False, hdlc_encoded=False)
+            if parse_result is not None:
+                self.postprocess_parse_result(parse_result)
 
     def read_dump(self):
         while self.io_device.file_available:


### PR DESCRIPTION
Newer qualcomm devices use qdss/bin logs by default, there're (proprietary) tools that can convert these logs to hdf, support for hdf avoids double conversion (qdss -> hdf -> dlf).

It's marked as experimental because it's a bit naive and may not handle some corner cases correctly.
I tested it with several samples, it decodes the same messages decoded by dlf parser.