### PR TITLE
Add an option to disable crc check

### DIFF
--- a/src/scat/main.py
+++ b/src/scat/main.py
@@ -79,6 +79,7 @@ def scat_main():
         qc_group.add_argument('--events', action='store_true', help='Decode Events as GSMTAP logging')
         qc_group.add_argument('--msgs', action='store_true', help='Decode Extended Message Reports and QSR Message Reports as GSMTAP logging')
         qc_group.add_argument('--cacombos', action='store_true', help='Display raw values of UE CA combo information on 4G/5G (0xB0CD/0xB826)')
+        qc_group.add_argument('--disable-crc-check', action='store_true', help='Disable CRC mismatch checks. Improves performance by avoiding CRC calculations.')
 
     if 'sec' in parser_dict.keys():
         sec_group = parser.add_argument_group('Samsung specific settings')
@@ -90,6 +91,7 @@ def scat_main():
         hisi_group = parser.add_argument_group('HiSilicon specific settings')
         try:
             hisi_group.add_argument('--msgs', action='store_true', help='Decode debug messages GSMTAP logging')
+            hisi_group.add_argument('--disable-crc-check', action='store_true', help='Disable CRC mismatch checks. Improves performance by avoiding CRC calculations.')
         except argparse.ArgumentError:
             pass
 
@@ -164,7 +166,8 @@ def scat_main():
             'events': args.events,
             'msgs': args.msgs,
             'cacombos': args.cacombos,
-            'combine-stdout': args.combine_stdout})
+            'combine-stdout': args.combine_stdout,
+            'disable-crc-check': args.disable_crc_check})
     elif args.type == 'sec':
         current_parser.set_parameter({
             'model': args.model,
@@ -173,7 +176,8 @@ def scat_main():
     elif args.type == 'hisi':
         current_parser.set_parameter({
             'msgs': args.msgs,
-            'combine-stdout': args.combine_stdout})
+            'combine-stdout': args.combine_stdout,
+            'disable-crc-check': args.disable_crc_check})
 
     # Run process
     if args.serial or args.usb:

--- a/src/scat/parsers/hisilicon/hisiliconparser.py
+++ b/src/scat/parsers/hisilicon/hisiliconparser.py
@@ -88,14 +88,14 @@ class HisiliconParser:
     def prepare_diag(self):
         pass
 
-    def parse_diag(self, pkt, hdlc_encoded = True, check_crc = True, args = None):
+    def parse_diag(self, pkt, hdlc_encoded = True, has_crc = True, args = None):
         if len(pkt) < 3:
             return
 
         if hdlc_encoded:
             pkt = util.unwrap(pkt)
 
-        if check_crc:
+        if has_crc:
             crc = util.dm_crc16(pkt[:-2])
             crc_pkt = (pkt[-1] << 8) | pkt[-2]
             if crc != crc_pkt:

--- a/src/scat/parsers/hisilicon/hisiliconparser.py
+++ b/src/scat/parsers/hisilicon/hisiliconparser.py
@@ -37,6 +37,7 @@ class HisiliconParser:
         self.io_device = None
         self.writer = None
         self.combine_stdout = False
+        self.check_crc = True
 
         self.name = 'hisilicon'
         self.shortname = 'hisi'
@@ -81,6 +82,8 @@ class HisiliconParser:
                 self.msgs = params[p]
             elif p == 'combine-stdout':
                 self.combine_stdout = params[p]
+            elif p == 'disable-crc-check':
+                self.check_crc = not params[p]
 
     def init_diag(self):
         pass
@@ -96,11 +99,13 @@ class HisiliconParser:
             pkt = util.unwrap(pkt)
 
         if has_crc:
-            crc = util.dm_crc16(pkt[:-2])
-            crc_pkt = (pkt[-1] << 8) | pkt[-2]
-            if crc != crc_pkt:
-                self.logger.log(logging.WARNING, "CRC mismatch: expected 0x{:04x}, got 0x{:04x}".format(crc, crc_pkt))
-                self.logger.log(logging.DEBUG, util.xxd(pkt))
+            # Check CRC only if check_crc is enabled
+            if self.check_crc:
+                crc = util.dm_crc16(pkt[:-2])
+                crc_pkt = (pkt[-1] << 8) | pkt[-2]
+                if crc != crc_pkt:
+                    self.logger.log(logging.WARNING, "CRC mismatch: expected 0x{:04x}, got 0x{:04x}".format(crc, crc_pkt))
+                    self.logger.log(logging.DEBUG, util.xxd(pkt))
             pkt = pkt[:-2]
 
         return self.parse_diag_log(pkt)

--- a/src/scat/parsers/qualcomm/qualcommparser.py
+++ b/src/scat/parsers/qualcomm/qualcommparser.py
@@ -258,7 +258,7 @@ class QualcommParser:
         else:
             self.io_device.write_then_read_discard(util.generate_packet(diagcmd.log_mask_scat_lte()), 0x1000, False)
 
-    def parse_diag(self, pkt, hdlc_encoded = True, check_crc = True, args = None):
+    def parse_diag(self, pkt, hdlc_encoded = True, has_crc = True, args = None):
         # Should contain DIAG command and CRC16
         # pkt should not contain trailing 0x7E, and either HDLC encoded or not
         # When the pkt is not HDLC encoded, hdlc_encoded should be set to True
@@ -271,7 +271,7 @@ class QualcommParser:
             pkt = util.unwrap(pkt)
 
         # Check and strip CRC if existing
-        if check_crc:
+        if has_crc:
             crc = util.dm_crc16(pkt[:-2])
             crc_pkt = (pkt[-1] << 8) | pkt[-2]
             if crc != crc_pkt:
@@ -359,7 +359,7 @@ class QualcommParser:
                 # DLF lacks CRC16/other fancy stuff
                 pkt = buf[0:pkt_len]
                 pkt = b'\x10\x00' + pkt[0:2] + pkt
-                parse_result = self.parse_diag(pkt, check_crc=False, hdlc_encoded=False)
+                parse_result = self.parse_diag(pkt, has_crc=False, hdlc_encoded=False)
 
                 if parse_result is not None:
                     self.postprocess_parse_result(parse_result)
@@ -405,7 +405,7 @@ class QualcommParser:
             body += self.io_device.read(pkt_len - 2)
             pkt = header + body
 
-            parse_result = self.parse_diag(pkt, check_crc=False, hdlc_encoded=False)
+            parse_result = self.parse_diag(pkt, has_crc=False, hdlc_encoded=False)
             if parse_result is not None:
                 self.postprocess_parse_result(parse_result)
 
@@ -585,7 +585,7 @@ class QualcommParser:
         pkt_header = self.multisim_header._make(struct.unpack('<BBHL', pkt[0:8]))
         pkt_body = pkt[8:]
 
-        ret = self.parse_diag(pkt_body, hdlc_encoded=False, check_crc=False, args={'radio_id': self.sanitize_radio_id(pkt_header.radio_id)})
+        ret = self.parse_diag(pkt_body, hdlc_encoded=False, has_crc=False, args={'radio_id': self.sanitize_radio_id(pkt_header.radio_id)})
         if type(ret) == dict:
             ret['radio_id'] = self.sanitize_radio_id(pkt_header.radio_id)
         return ret


### PR DESCRIPTION
Calculating CRCs can dramatically slowdown decoding.

To demonstrate this, I tried decoding a 2GB qmdl with and without CRC checks on two different machines.

Machine A is a Laptop with Windows 11 and Python 3.11
Machine B is a Raspberry Pi4 with Debian 11 and Python 3.9

command with crc enabled is: `scat -t qc -d 2GB.qmdl`
command with crc disabled is: `scat -t qc -d 2GB.qmdl --disable-crc-check`

These are the results after 3 runs:
|| avg (s) | min (s) | max (s) |
|----------------------|---------|---------|---------|
| machineA-crc-enabled         |  310.93 |  299.96 |  319.14 |
| machineA-crc-disabled |   55.28 |   53.51 |   56.52 |
| machineB-crc-enabled         | 1051.93 | 1048.01 | 1054.50 |
| machineB-crc-disabled |  266.77 |  264.60 |  268.75 |

Decoding that huge qmdl takes 4-6x more time with CRC checks enabled