### PR TITLE
sdm: support logger timestamp

### DIFF
--- a/src/scat/util.py
+++ b/src/scat/util.py
@@ -119,6 +119,22 @@ def xxd_oneline(buf, stdout = False):
     else:
         return 'Hexdump: \n' + xxd_str
 
+def parse_sdm_ts(ts_upper_32bits, ts_lower_16bits):
+    # ts_upper_32bits + ts_lower_16bits = 48bits unsigned int = milliseconds since epoch
+    ts_upper = ts_upper_32bits << 16
+    ts_ms = ts_upper + ts_lower_16bits
+    ts_s = ts_ms / 1000.0
+
+    if ts_s == 0:
+      return datetime.datetime.now()
+    
+    try:
+        date = datetime.datetime.utcfromtimestamp(ts_s)
+    except OverflowError:
+        date = datetime.datetime.now()
+    
+    return date
+
 # Definition copied from libosmocore's include/osmocom/core/gsmtap.h
 
 @unique


### PR DESCRIPTION
Logger timestamp, is a timestamp added by application logger, it's stored as 48 bits unsigned int representing milliseconds since epoch. The timezone is specified in sdm file header,  but that header isn't supported by _scat_.

This is an example of _SdmLoggerHeader_:

```
magic: 39 7f
logger_ts: b3 80 8a 85 72 01 = 1591378346163 = Friday 5 June 2020 17:32:26.163
seqnr: 05 29
direction: a0
group: 22
command: 52 
timestamp: 3c a6 fa 1d = 502965820 = 503s (since modem boot? since log start?)
```
This is an example of _SdmFileHeader_:
```
magic: 39fd 
unknown: 040002000000
ver_len: 0500
ver_str: 312e352e31 = 1.5.1
epoch_len: 0800
epoch: e337878572010000 = 1591378130915 = Friday 5 June 2020 17:28:50.915
tz_len: 0700 
tz_str: 4574632f474d54 = Etc/GMT
tz2_len: 0500
tz2_str: 454d505459 = EMPTY
```
