### PR TITLE
Always use UTC for sdm timestamps

### DIFF
--- a/src/scat/util.py
+++ b/src/scat/util.py
@@ -129,7 +129,7 @@ def parse_sdm_ts(ts_upper_32bits, ts_lower_16bits):
       return datetime.datetime.now()
     
     try:
-        date = datetime.datetime.utcfromtimestamp(ts_s)
+        date = datetime.datetime.fromtimestamp(ts_s, tz=datetime.timezone.utc)
     except OverflowError:
         date = datetime.datetime.now()
     


### PR DESCRIPTION
The current code uses utcfromtimestamp that returns a naive datetime object, naive datetime objects are often treated as local times.