### PR TITLE
Add new NR RRC OTA packet version 0x13, 0x17 + SCell version 0x30003 + MM State version 0x30000 to support S23 Ultra and S24 Ultra

### DIFF
--- a/src/scat/parsers/qualcomm/diagltelogparser.py
+++ b/src/scat/parsers/qualcomm/diagltelogparser.py
@@ -1169,7 +1169,11 @@ class DiagLteLogParser:
         item_struct_v25 = namedtuple('QcDiagLteRrcOtaPacketV25', 'rrc_rel_maj rrc_rel_min nr_rrc_rel_maj nr_rrc_rel_min rbid pci earfcn sfn_subfn pdu_num sib_mask len')
         item = None
 
-        if pkt_version >= 25:
+        if pkt_version >= 30:
+            # Version 30
+            item = item_struct_v25._make(struct.unpack('<BBBB BHLH BLH3x', pkt_body[1:24]))
+            msg_content = pkt_body[24:]
+        elif pkt_version >= 25:
             # Version 25, 26, 27
             item = item_struct_v25._make(struct.unpack('<BBBB BHLH BLH', pkt_body[1:21]))
             msg_content = pkt_body[21:]
@@ -1242,8 +1246,8 @@ class DiagLteLogParser:
                 8: util.gsmtap_lte_rrc_types.UL_CCCH,
                 9: util.gsmtap_lte_rrc_types.UL_DCCH
             }
-        elif pkt_version in (0x13, 0x1a, 0x1b):
-            # RRC Packet v19, v26, v27
+        elif pkt_version in (0x13, 0x1a, 0x1b, 0x1e):
+            # RRC Packet v19, v26, v27, v30
             rrc_subtype_map = {
                 1: util.gsmtap_lte_rrc_types.BCCH_BCH,
                 3: util.gsmtap_lte_rrc_types.BCCH_DL_SCH,

--- a/src/scat/parsers/qualcomm/diagnrlogparser.py
+++ b/src/scat/parsers/qualcomm/diagnrlogparser.py
@@ -61,6 +61,12 @@ class DiagNrLogParser:
         elif pkt_ver in (0x11, ): # Version 17
             item = item_struct_v17._make(struct.unpack('<BBBH Q I3sBIH', pkt_body[4:31]))
             msg_content = pkt_body[31:]
+        elif pkt_ver in (0x13, ): # Version 19
+            item = item_struct_v17._make(struct.unpack('<BBBH Q I3sBIHx', pkt_body[4:32]))
+            msg_content = pkt_body[32:]
+        elif pkt_ver in (0x17, ): # Version 23
+            item = item_struct_v17._make(struct.unpack('<BBBH Q I3sBIH4x', pkt_body[4:35]))
+            msg_content = pkt_body[35:]
         else:
             if self.parent:
                 self.parent.logger.log(logging.WARNING, 'Unknown NR RRC OTA Message packet version {:#x}'.format(pkt_ver))
@@ -99,7 +105,7 @@ class DiagNrLogParser:
                 32: "UE_NR_CAPABILITY",
                 33: "UE_NR_CAPABILITY",
             }
-        elif pkt_ver in (0x11, ):
+        elif pkt_ver in (0x11, 0x13, ):
             rrc_type_map = {
                 1: "BCCH_BCH",
                 2: "BCCH_DL_SCH",
@@ -111,6 +117,21 @@ class DiagNrLogParser:
                 8: "UL_DCCH",
                 9: "RRC_RECONFIGURATION",
                 10: "RRC_RECONFIGURATION_COMPLETE",
+                29: "nr-RadioBearerConfig",
+            }
+        elif pkt_ver in (0x17, ):
+           rrc_type_map = {
+                1: "BCCH_BCH",
+                2: "BCCH_DL_SCH",
+                3: "DL_CCCH",
+                4: "DL_DCCH",
+                5: "MCCH",
+                6: "PCCH",
+                7: "UL_CCCH",
+                8: "UL_CCCH1",
+                9: "UL_DCCH",
+                10: "RRC_RECONFIGURATION",
+                11: "RRC_RECONFIGURATION_COMPLETE",
                 29: "nr-RadioBearerConfig",
             }
 

--- a/src/scat/parsers/qualcomm/diagnrlogparser.py
+++ b/src/scat/parsers/qualcomm/diagnrlogparser.py
@@ -132,7 +132,7 @@ class DiagNrLogParser:
                 9: "UL_DCCH",
                 10: "RRC_RECONFIGURATION",
                 11: "RRC_RECONFIGURATION_COMPLETE",
-                29: "nr-RadioBearerConfig",
+                36: "nr-RadioBearerConfig",
             }
 
         pkt_ts = util.parse_qxdm_ts(pkt_header.timestamp)

--- a/src/scat/parsers/qualcomm/diagnrlogparser.py
+++ b/src/scat/parsers/qualcomm/diagnrlogparser.py
@@ -197,7 +197,7 @@ class DiagNrLogParser:
         elif pkt_ver == 0x30000:
             # PCI 2b, NR CGI 8b, DL NR-ARFCN 4b, UL NR-ARFCN 4b, DLBW 2b, ULBW 2b, Cell ID 8b, MCC 2b, MCC digit 1b, MNC 2b, MNC digit 1b, TAC 4b, ?
             item = item_struct_v30000._make(struct.unpack('<H Q LLHH Q H BH B LH', pkt_body[4:46]))
-        elif pkt_ver == 0x30002:
+        elif pkt_ver in (0x30002, 0x30003, ):
             # ? 3b, PCI 2b, NR CGI 8b, DL NR-ARFCN 4b, UL NR-ARFCN 4b, DLBW 2b, ULBW 2b, Cell ID 8b, MCC 2b, MCC digit 1b, MNC 2b, MNC digit 1b, TAC 4b, ?
             item = item_struct_v30000._make(struct.unpack('<H Q LLHH Q H BH B LH', pkt_body[7:49]))
         else:
@@ -256,7 +256,7 @@ class DiagNrLogParser:
         pkt_ts = util.parse_qxdm_ts(pkt_header.timestamp)
         pkt_ver = struct.unpack('<I', pkt_body[0:4])[0]
 
-        if pkt_ver == 0x01: # Version 1
+        if pkt_ver in (0x01, 0x30000, ): # Version 1 and 196608
             item_struct = namedtuple('QcDiagNrNasMmState', 'mm_state mm_substate plmn_id guti_5gs mm_update_status tac')
             item = item_struct._make(struct.unpack('<BH3s12sb3s', pkt_body[4:26]))
             plmn_id = util.unpack_mcc_mnc(item.plmn_id)

--- a/tests/test_diagltelogparser.py
+++ b/tests/test_diagltelogparser.py
@@ -136,6 +136,15 @@ class TestDiagLteLogParser(unittest.TestCase):
 
     # LTE RRC
     def test_parse_lte_rrc(self):
+        # V30
+        payload = binascii.unhexlify('1e112011400132001914000016ad090000000002000000004c10')
+        pkt_header = self.log_header(cmd_code=0x10, reserved=0, length1=len(payload) + 12, length2=len(payload) + 12,
+                                     log_id=diagcmd.diag_log_get_lte_item_id(diagcmd.diag_log_code_lte.LOG_LTE_RRC_OTA_MESSAGE), timestamp=0)
+        result = self.parser.parse_lte_rrc(pkt_header, payload, None)
+        expected = {'cp': [binascii.unhexlify('03070d001419000000000ad1010006000000000012d53d80000000004c10')],
+            'ts': datetime.datetime(1980, 1, 6, 0, 0, tzinfo=datetime.timezone.utc)}
+        self.assertDictEqual(result, expected)
+ 
         # V27
         # payload = binascii.unhexlify('1b10100f9000b10186a00000d50700000000070005') # ...
         # pkt_header = self.log_header(cmd_code=0x10, reserved=0, length1=len(payload) + 12, length2=len(payload) + 12, log_id=0xb0c0, timestamp=0)

--- a/tests/test_diagnrlogparser.py
+++ b/tests/test_diagnrlogparser.py
@@ -65,12 +65,31 @@ class TestDiagNrLogParser(unittest.TestCase):
             'ts': datetime.datetime(1980, 1, 6, 0, 0, tzinfo=datetime.timezone.utc)}
         self.assertDictEqual(result, expected)
 
+        # Version 0x30003
+        payload = binascii.unhexlify('030003000101004b0001c83b57252230001aee0100080e02000a000a0001c83b57050000002e0103dc00008eb921004700')
+        pkt_header = self.log_header(cmd_code=0x10, reserved=0, length1=len(payload) + 12, length2=len(payload) + 12,
+                                     log_id=diagcmd.diag_log_get_lte_item_id(diagcmd.diag_log_code_5gnr.LOG_5GNR_RRC_SERVING_CELL_INFO), timestamp=0)
+        result = self.parser.parse_nr_rrc_scell_info(pkt_header, payload, None)
+        expected = {'stdout': 'NR RRC SCell Info: NR-ARFCN 126490/134664, Bandwidth 10/10 MHz, Band 71, PCI   75, xTAC/xCID 21b98e/5573bc801, MCC 302, MNC 220',
+            'ts': datetime.datetime(1980, 1, 6, 0, 0, tzinfo=datetime.timezone.utc)}
+        self.assertDictEqual(result, expected)
+
+
     def test_parse_nr_mm_state(self):
         payload = binascii.unhexlify('0100000003000054f0800254f080a206001636ac480400a040fe')
         pkt_header = self.log_header(cmd_code=0x10, reserved=0, length1=len(payload) + 12, length2=len(payload) + 12,
                                      log_id=diagcmd.diag_log_get_lte_item_id(diagcmd.diag_log_code_5gnr.LOG_5GNR_NAS_5GMM_STATE), timestamp=0)
         result = self.parser.parse_nr_mm_state(pkt_header, payload, None)
         expected = {'stdout': '5GMM State: 3/0/0, PLMN: 450/  8, TAC: a040fe, GUTI: 450-008-a2-006-16-0448ac36',
+            'ts': datetime.datetime(1980, 1, 6, 0, 0, tzinfo=datetime.timezone.utc)}
+        self.assertDictEqual(result, expected)
+
+        # Version 0x30000
+        payload = binascii.unhexlify('000003000300000302220203022255c40332d6c214c00021b98e00')
+        pkt_header = self.log_header(cmd_code=0x10, reserved=0, length1=len(payload) + 12, length2=len(payload) + 12,
+                                     log_id=diagcmd.diag_log_get_lte_item_id(diagcmd.diag_log_code_5gnr.LOG_5GNR_NAS_5GMM_STATE), timestamp=0)
+        result = self.parser.parse_nr_mm_state(pkt_header, payload, None)
+        expected = {'stdout': '5GMM State: 3/0/0, PLMN: 302/220, TAC: 21b98e, GUTI: 302-220-55-3c4-32-c014c2d6',
             'ts': datetime.datetime(1980, 1, 6, 0, 0, tzinfo=datetime.timezone.utc)}
         self.assertDictEqual(result, expected)
 


### PR DESCRIPTION
Hello,

This PR adds new qualcomm parser packet versions for RRC OTA, SCell, and MM state packets to support printing 5G info and RRC packets for newer Samsung phones like Samsung Galaxy S23 Ultra and Galaxy S24 Ultra.

From the debug messages shown below, you can see that the S23 Ultra uses NR RRC OTA packet version 0x13, and S24 Ultra uses version 0x17. From examining the hexdump of these messages, you can see that padding has been added between the message length field and the message payload (which is different than previous versions that didn't seem to have any padding after the length). For version 0x13 there is extra one byte padding, and for 0x17 there is extra four byte padding. I added this padding in struct.unpack and offset the message start index for these versions to account for this padding.

Here is the debug output of an RRC OTA message (UECapabilityEnquiry) from my S23 Ultra. You can see the message length is 0x0019 (25) and that there is a single byte padding after the length (padding is bolded below).

> 2024-02-24 21:04:50,407 scat.qualcommparser (parse_nr_rrc) WARNING: Unknown NR RRC OTA Message packet version 0x13
> 2024-02-24 21:04:50,407 scat.qualcommparser (parse_nr_rrc) DEBUG: Body: Hexdump: 
> 13 00 00 00 10 90 01 7d 02 02 c8 3b 57 25 22 30 00 1a ee 01 00 20 0e ff 04 00 00 00 00 19 00 ***00*** 30 42 44 e0 15 01 1a 02 0c 04 d0 02 00 c0 20 06 01 60 30 08 04 10 00 60 00
> -------- end --------

Here is the same message from my S24 Ultra. You can see the message length is 0x0019 (25) again but this time there is a four byte padding after the length field (padding is bolded below).

> 2024-02-24 16:25:38,214 scat.qualcommparser (parse_nr_rrc) WARNING: Unknown NR RRC OTA Message packet version 0x17
> 2024-02-24 16:25:38,214 scat.qualcommparser (parse_nr_rrc) DEBUG: Body: Hexdump: 
> 17 00 00 00 11 40 01 80 03 01 d0 3b 57 25 22 30 00 1a ee 01 00 20 54 07 04 00 00 00 00 19 00 ***00 00 00 00*** 36 42 44 e0 15 01 1a 02 0c 04 d0 02 00 c0 20 06 01 60 30 08 04 10 00 60 00
> -------- end --------

Also for version 0x17, a new MCCH message type was added as shown in the protocol [here](https://nrexplained.com/rrc/h60). So I added that as well, or else my messages for 0x17 had wrong types.

After the above changes, scat is outputting the correct Body and type for RRC OTA packets on my S23U and S24U as shown in this [attached output log](https://github.com/fgsect/scat/files/14395532/scat-output-s24u-fixed.txt), and I am able to successfully parse the Body to a RRC packet using Wireshark dissector of the correct type (e.g.: UL_DCCH, etc) as shown in this [picture](https://github.com/fgsect/scat/assets/58204/f5477583-9680-4cb5-9817-30f6f879e1f4).

**Disclaimer:** Even though the above padding seems to work, I could not find information for this header in the protocol documentation, so I have no idea whether this padding is just new padding or a new header field. I also do not have a background in telecommunications so I am not sure where to look for this information exactly. If you could please review and confirm whether this is correct (or suggest how to do this correctly if not correct), that would be great. 

As for 5G SCell and 5G MM messages, I was getting this error in the logs for S24 Ultra only:

```
2024-02-24 16:25:49,360 scat.qualcommparser (parse_nr_rrc_scell_info) WARNING: Unknown NR SCell Information packet version 30003
2024-02-24 16:25:49,365 scat.qualcommparser (parse_nr_mm_state) WARNING: Unknown NR MM State packet version 196608
```

After adding these versions without any other modifications, I am able to see the correct info as shown below. So I think that's all that's needed for this. But again, I did not look to see if the updated protocol has added anything more to these packet versions that needs to be addressed, so please review.

```
Radio 1: NR RRC SCell Info: NR-ARFCN 126490/134664, Bandwidth 10/10 MHz, Band 71, PCI   75, xTAC/xCID 21b98e/5573bc801, MCC 302, MNC 220
Radio 1: 5GMM State: 3/0/0, PLMN: 302/220, TAC: 21b98e, GUTI: 302-220-55-3c4-3a-d031c24a
```