### PR TITLE
add systemd watchdog support

### DIFF
--- a/src/scat/writers/pcapwriter.py
+++ b/src/scat/writers/pcapwriter.py
@@ -5,6 +5,7 @@ import datetime
 import struct
 
 from scat.writers.abstractwriter import AbstractWriter
+from scat.writers.systemd_notify import systemd_notify_watchdog_alive
 
 class PcapWriter(AbstractWriter):
     def __init__(self, filename: str, port_cp: int = 4729, port_up: int = 47290):
@@ -66,6 +67,7 @@ class PcapWriter(AbstractWriter):
             self.ip_id = 0
 
     def write_cp(self, sock_content: bytes, radio_id: int=0, ts: datetime.datetime=datetime.datetime.now()):
+        systemd_notify_watchdog_alive()
         self.write_pkt(sock_content, self.port_cp, radio_id, ts)
 
     def write_up(self, sock_content: bytes, radio_id: int=0, ts: datetime.datetime=datetime.datetime.now()):

--- a/src/scat/writers/rawwriter.py
+++ b/src/scat/writers/rawwriter.py
@@ -2,6 +2,7 @@
 # coding: utf8
 
 from scat.writers.abstractwriter import AbstractWriter
+from scat.writers.systemd_notify import systemd_notify_watchdog_alive
 
 class RawWriter(AbstractWriter):
     def __init__(self, fname: str, header: bytes=b'', trailer: bytes=b''):
@@ -13,6 +14,7 @@ class RawWriter(AbstractWriter):
         return self
 
     def write_cp(self, sock_content: bytes, radio_id: int=0, ts: None = None):
+        systemd_notify_watchdog_alive()
         self.raw_file.write(sock_content)
 
     def write_up(self, sock_content: bytes, radio_id: int=0, ts: None = None):

--- a/src/scat/writers/socketwriter.py
+++ b/src/scat/writers/socketwriter.py
@@ -5,6 +5,7 @@ import socket
 import struct
 
 from scat.writers.abstractwriter import AbstractWriter
+from scat.writers.systemd_notify import systemd_notify_watchdog_alive
 
 class SocketWriter(AbstractWriter):
     def __init__(self, base_address: str, port_cp: int = 4729, port_up: int = 47290):
@@ -21,6 +22,7 @@ class SocketWriter(AbstractWriter):
         return self
 
     def write_cp(self, sock_content: bytes, radio_id: int=0, ts: None = None):
+        systemd_notify_watchdog_alive()
         if radio_id <= 0:
             dest_address = self.base_address
         else:

--- a/src/scat/writers/systemd_notify.py
+++ b/src/scat/writers/systemd_notify.py
@@ -1,0 +1,4 @@
+import subprocess
+
+def systemd_notify_watchdog_alive():
+    subprocess.run(["systemd-notify", "WATCHDOG=1"], check=True)


### PR DESCRIPTION
I added systemd watchdog support, so I can run the service reliably in a headless setup. Right now I am using a subprocess call to the `system-notify` cli tool on every GSMTAP file write.  
This is my systemd service:  
`scat.service`
```
[Unit]
Description=scat

[Service]
Type=simple
ExecStart=/usr/local/bin/scat-run.sh
WatchdogSec=60
Restart=always
RestartSec=5

[Install]
WantedBy=multi-user.target
```
and the script `scat-run.sh` ensures that every run saves to a new pcap file:
```
#!/bin/sh
ts=$(date +"%Y%m%d-%H%M%S")
exec /usr/local/bin/scat -u -i 4 -t sec -L "nas,rrc" -m e303 -F "/var/log/scat-$ts.pcap"
```

This works for me. Do you have interest in integrating this functionality upstream? 
I could also use the [systemd-watchdog](https://github.com/AaronDMarasco/systemd-watchdog) python library for improved performance instead of calling the cli via a subprocess, but this would introduce a new dependency. We could make it optional like the fastcrc functionality.  
Thank you for this great project.