### PR TITLE
Add bounds checks for truncated DLF packet parsing

### DIFF
--- a/src/scat/parsers/qualcomm/diagltelogparser.py
+++ b/src/scat/parsers/qualcomm/diagltelogparser.py
@@ -690,10 +690,14 @@ class DiagLteLogParser:
         subpkt_pos = 1
         for j in range(n_samples):
             if subpkt_hdr.version == 0x01:
+                if subpkt_pos + 12 > len(subpkt_body):
+                    break
                 subpkt_mac_ul_tb = subpkt_mac_ul_tb_struct._make(struct.unpack('<BBHHBHBBB', subpkt_body[subpkt_pos:subpkt_pos+12]))
                 mac_hdr = subpkt_body[subpkt_pos+12:subpkt_pos+12+subpkt_mac_ul_tb.header_len]
                 subpkt_pos += (12 + subpkt_mac_ul_tb.header_len)
             elif subpkt_hdr.version == 0x02 or subpkt_hdr.version == 0x03 or subpkt_hdr.version == 0x05 or subpkt_hdr.version == 0x08:
+                if subpkt_pos + 14 > len(subpkt_body):
+                    break
                 subpkt_mac_ul_tb = subpkt_mac_ul_tb_struct_v2._make(struct.unpack('<BBBBHHBHBBB', subpkt_body[subpkt_pos:subpkt_pos+14]))
                 mac_hdr = subpkt_body[subpkt_pos+14:subpkt_pos+14+subpkt_mac_ul_tb.header_len]
                 subpkt_pos += (14 + subpkt_mac_ul_tb.header_len)
@@ -759,6 +763,8 @@ class DiagLteLogParser:
         if pkt_version == 0x31:
             pos += (19 * 28)
         for i in range(num_tb):
+            if pos + 16 > len(pkt_body):
+                break
             subpkt_tb = subpkt_tb_common_info._make(struct.unpack('<LLL B B H', pkt_body[pos:pos+16]))
             pos += 16
 
@@ -774,6 +780,8 @@ class DiagLteLogParser:
             mac_hdr_len = var3_bits[0:12].uint
 
             for j in range(subpkt_tb.num_sdu):
+                if pos + 3 > len(pkt_body):
+                    break
                 mac_common_info_bits = bitstring.Bits(pkt_body[pos:pos+3][::-1])
                 is_mce = mac_common_info_bits[0:1].uint
                 lcid = mac_common_info_bits[1:7].uint
@@ -831,6 +839,8 @@ class DiagLteLogParser:
                     for k in range(num_pdcp_grp):
                         has_more = 1
                         while has_more == 1:
+                            if pos + 4 > len(pkt_body):
+                                break
                             pdcp_grp_bits = bitstring.Bits(pkt_body[pos:pos+4][::-1])
                             has_more = pdcp_grp_bits[0:1].uint
                             pos += 4

--- a/src/scat/writers/pcapwriter.py
+++ b/src/scat/writers/pcapwriter.py
@@ -29,6 +29,9 @@ class PcapWriter(AbstractWriter):
         return self
 
     def write_pkt(self, sock_content: bytes, port: int, radio_id: int=0, ts: datetime.datetime = datetime.datetime.now()) -> None:
+        max_payload = 65535 - 8 - 20  # max UDP payload fitting in IPv4
+        if len(sock_content) > max_payload:
+            return
         pcap_hdr = struct.pack('<LLLL',
                 int(ts.timestamp()) % 4294967296,
                 ts.microsecond,


### PR DESCRIPTION
When parsing DLF log files, packets can be shorter than expected due to capture truncation (logged as 'Packet length mismatch' warnings). Without bounds checks, these produce crashes:
- ValueError from bitstring when reading a zero-length slice
- struct.error when unpacking from a buffer that is too short
- struct.error when writing oversized packets to pcap

Fix by adding guards before each fixed-size read in:
- parse_lte_mac_subpkt_v49: TB common info (16B), SDU info (3B), pdcp_grp (4B)
- parse_lte_mac_subpkt_v1_ul_transport_block: UL TB headers (12B/14B)
- PcapWriter.write_pkt: skip packets exceeding IPv4 max payload (65507B)

For transparency, AI was used to debug these errors.