### PR TITLE
scat: create tcpio iodevice

### DIFF
--- a/src/scat/iodevices/__init__.py
+++ b/src/scat/iodevices/__init__.py
@@ -5,3 +5,4 @@ from scat.iodevices.abstractio import AbstractIO
 from scat.iodevices.usbio import USBIO
 from scat.iodevices.serialio import SerialIO
 from scat.iodevices.fileio import FileIO
+from scat.iodevices.tcpio import TCPIO

--- a/src/scat/iodevices/tcpio.py
+++ b/src/scat/iodevices/tcpio.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# coding: utf8
+
+import sys
+from socket import socket, AF_INET, SOCK_STREAM
+import scat.util as util
+from scat.iodevices.abstractio import AbstractIO
+
+class TCPIO(AbstractIO):
+    def __init__(self, address: str, port: int):
+        self.socket = socket(AF_INET, SOCK_STREAM)
+        self.block_until_data = True
+        
+        try:
+            self.socket.connect((address, port))
+            self.socket.settimeout(0.1)
+        except ConnectionRefusedError as e:
+            print(f'Error: Port connection refused addr: {address}:{port} is diag running?')
+            sys.exit(1)
+
+    def open_next_file(self) -> None:
+        pass
+
+    def read(self, read_size: int, decode_hdlc: bool = False) -> bytes:
+        try:
+            buf = self.socket.recv(read_size)
+            if decode_hdlc:
+                buf = util.unwrap(buf)
+            return buf
+        except TimeoutError:
+            return b''
+    
+    def write(self, write_buf: bytes, encode_hdlc:bool = False) -> None:
+        if encode_hdlc:
+            write_buf: bytes = util.wrap(write_buf)
+        self.socket.send(write_buf)
+    
+    def write_then_read_discard(self, write_buf: bytes, read_size: int = 0x1000, encode_hdlc: bool = False) -> None:
+        self.write(write_buf, encode_hdlc)
+        self.read(read_size)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.socket.close()
+    

--- a/src/scat/main.py
+++ b/src/scat/main.py
@@ -69,6 +69,7 @@ def scat_main():
     input_group = parser.add_mutually_exclusive_group(required=True)
     input_group.add_argument('-s', '--serial', help='Use serial diagnostic port')
     input_group.add_argument('-u', '--usb', action='store_true', help='Use USB diagnostic port')
+    input_group.add_argument('-T', '--tcp', metavar='HOST:PORT', help='Use tcp socket diagnostic port (adress:port)')
     input_group.add_argument('-d', '--dump', help='Read from baseband dump (QMDL, SDM, LPD)', nargs='*')
 
     serial_group = parser.add_argument_group('Serial device settings')
@@ -142,6 +143,11 @@ def scat_main():
     io_device: scat.iodevices.AbstractIO
     if args.serial:
         io_device = scat.iodevices.SerialIO(args.serial, args.baudrate, not args.no_rts, not args.no_dsr)
+    elif args.tcp:
+        address, port = args.tcp.split(':')
+        address = str(address)
+        port = int(port, base= 10)
+        io_device =scat.iodevices.TCPIO(address, port)
     elif args.usb:
         io_device = scat.iodevices.USBIO()
         if args.address:
@@ -224,7 +230,7 @@ def scat_main():
             'gsmtapv3': args.gsmtapv3})
 
     # Run process
-    if args.serial or args.usb:
+    if args.serial or args.usb or args.tcp:
         current_parser.stop_diag()
         current_parser.init_diag()
         current_parser.prepare_diag()


### PR DESCRIPTION
TCP is needed when you want to consume diag packets from diag-router directly inside the apps processor in the modem.