### PR TITLE
diaggsmparser: fix format parameter in parse_gsm_l1_surround_cell_ba

### DIFF
--- a/src/scat/parsers/qualcomm/diaggsmlogparser.py
+++ b/src/scat/parsers/qualcomm/diaggsmlogparser.py
@@ -180,7 +180,7 @@ class DiagGsmLogParser:
             if item.bsic_valid == 1:
                 stdout += 'GSM Surround Cell BA: Cell {}: ARFCN: {}/BC: {}/BSIC: {}, RxPwr: {:.2f}\n'.format(i, s_arfcn, s_band, item.bsic, s_rxpwr_real)
             else:
-                stdout += 'GSM Surround Cell BA: Cell {}: ARFCN: {}/BC: {}/BSIC: N/A, RxPwr: {:.2f}\n'.format(i, s_arfcn, s_band, item.bsic, s_rxpwr_real)
+                stdout += 'GSM Surround Cell BA: Cell {}: ARFCN: {}/BC: {}/BSIC: N/A, RxPwr: {:.2f}\n'.format(i, s_arfcn, s_band, s_rxpwr_real)
 
         return {'stdout': stdout.rstrip(), 'ts': pkt_ts}
 


### PR DESCRIPTION
In parse_gsm_l1_surround_cell_ba, when `item.bsic_valid` is not 1, it supplies 5 parameters in a 4-parameter format string, dropping `s_rxpwr_real` silently.

This patch fixes this and properly logs `s_rxpwr_real` instead of `item.bsic`.